### PR TITLE
Bump php version for PCI compliance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.6.33-apache
+FROM php:5.6.34-apache
 
 COPY assets/* /tmp/
 


### PR DESCRIPTION
PCI compliance requires PHP version 5.6.34 or greater.